### PR TITLE
Add NuGet package license/readme metadata to fix upload warnings

### DIFF
--- a/SmartWait/SmartWait.csproj
+++ b/SmartWait/SmartWait.csproj
@@ -12,6 +12,8 @@
     <PackageTags>SmartWait FluentWait Fluent Wait Smart Wait</PackageTags>
     <PackageReleaseNotes>update packages</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/valeraf23/SmartWait</RepositoryUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <AssemblyVersion>2.2.0.3</AssemblyVersion>
     <FileVersion>2.2.0.3</FileVersion>
     <PackageIcon>Logo.png</PackageIcon>
@@ -33,6 +35,10 @@
     <None Include="..\..\..\..\Desktop\Logo.png">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
+    </None>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>/</PackagePath>
     </None>
   </ItemGroup>
 


### PR DESCRIPTION
### Motivation
- Fix NuGet validation warnings by declaring the package license and readme so uploads recognize the repository `LICENSE` and `README.md` files.

### Description
- Add `PackageLicenseExpression` set to `Apache-2.0` and `PackageReadmeFile` set to `README.md` to `SmartWait/SmartWait.csproj`.
- Include the repository `README.md` in the package root via a `<None Include="..\README.md">` entry so the readme is packaged.

### Testing
- Attempted `dotnet pack SmartWait/SmartWait.csproj -c Release -o /tmp/smartwait-pack`, which failed because `dotnet` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a18fe752ec83219e0f856433144312)