### PR TITLE
Handle overflow in retry step calculation for wait engines

### DIFF
--- a/SmartWait/Core/Async/WaitEngineAsync.cs
+++ b/SmartWait/Core/Async/WaitEngineAsync.cs
@@ -65,7 +65,15 @@ namespace SmartWait.Core.Async
                 var remaining = maxWaitTime - stopwatchElapsed;
                 if (remaining <= TimeSpan.Zero) continue;
 
-                var sleep = stepEngine.Invoke(retryAttempt);
+                TimeSpan sleep;
+                try
+                {
+                    sleep = stepEngine.Invoke(retryAttempt);
+                }
+                catch (OverflowException)
+                {
+                    sleep = remaining;
+                }
                 var delay = sleep <= remaining ? sleep : remaining;
                 if (delay > TimeSpan.Zero)
                 {

--- a/SmartWait/Core/Sync/WaitEngine.cs
+++ b/SmartWait/Core/Sync/WaitEngine.cs
@@ -63,7 +63,15 @@ namespace SmartWait.Core.Sync
                 var remaining = maxWaitTime - stopwatchElapsed;
                 if (remaining <= TimeSpan.Zero) continue;
 
-                var sleep = stepEngine.Invoke(retryAttempt);
+                TimeSpan sleep;
+                try
+                {
+                    sleep = stepEngine.Invoke(retryAttempt);
+                }
+                catch (OverflowException)
+                {
+                    sleep = remaining;
+                }
                 var delay = sleep <= remaining ? sleep : remaining;
                 if (delay > TimeSpan.Zero)
                 {


### PR DESCRIPTION
### Motivation
- A test (`For_Failure_Return_ActuallyValue`) exposed a `System.OverflowException` when using an exponential backoff step function (e.g. `TimeSpan.FromSeconds(Math.Pow(2, retryAttempt))`) which overflowed `TimeSpan` before the normal timeout path could return a failure result. 
- The intent is to prevent user-provided step functions from throwing `OverflowException` and causing the wait loop to fail unexpectedly, preserving the intended timeout/failure semantics.

### Description
- Guarded the evaluation of the retry step in `WaitEngine` by wrapping `stepEngine.Invoke(retryAttempt)` in a `try/catch (OverflowException)` and falling back to sleeping the remaining allowed wait time. 
- Applied the same overflow handling change to the asynchronous engine in `WaitEngineAsync` with the same fallback behavior before `Task.Delay(...)`. 
- Preserved existing logic that clamps the sleep to the remaining time and continues to return the appropriate `FailureResult` or success when conditions are met.

### Testing
- The original automated run showed 60 tests executed with 59 passed and 1 failed due to `System.OverflowException` in `WaitForTest.For_Failure_Return_ActuallyValue`. 
- Attempted to re-run tests with `dotnet test` after the fix but could not run automated tests in this environment because `dotnet` is not installed (command returned `bash: command not found: dotnet`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1ba4f7a98832191d9cf9e00b249f3)